### PR TITLE
feat: add Sylius 2.0 / Symfony 7 compatibility, update routing config and CI

### DIFF
--- a/.github/workflows/sylius.yaml
+++ b/.github/workflows/sylius.yaml
@@ -13,23 +13,26 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - 8.1
           - 8.2
           - 8.3
         sylius:
-          - 1.12.0
-          - 1.13.0
           - 1.14.0
+          - 2.0.0
+        include:
+          - sylius: 1.14.0
+            node-version: '20'
+          - sylius: 2.0.0
+            node-version: '22'
     env:
       SYMFONY_ARGS: --no-tls
       COMPOSER_ARGS: --prefer-dist
       DOCKER_INTERACTIVE_ARGS: -t
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: ${{ matrix.node-version }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -47,7 +50,7 @@ jobs:
         run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-composer
         with:
           path: ${{ steps.composer-cache-directory.outputs.directory }}

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ when@test:
 
 ```yaml
 app_metrics:
-    resource: '@ArtprimaPrometheusMetricsBundle/Resources/config/routing.xml'
+    resource: '@ArtprimaPrometheusMetricsBundle/Resources/config/routing.yaml'
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "sylius/sylius": "^1.0 || ^2.0",
-        "artprima/prometheus-metrics-bundle": "~1.16.0 || ~1.17.0"
+        "sylius/sylius": "^1.14 || ^2.0",
+        "artprima/prometheus-metrics-bundle": "~1.21.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2"

--- a/dist/config/routes/metrics.yaml
+++ b/dist/config/routes/metrics.yaml
@@ -1,0 +1,5 @@
+# The Flex recipe for artprima/prometheus-metrics-bundle still references routing.xml
+# which no longer exists since v1.21.0. This file overrides it until the recipe is fixed.
+# See: https://github.com/symfony/recipes-contrib/pull/1948
+app_metrics:
+    resource: '@ArtprimaPrometheusMetricsBundle/Resources/config/routing.yaml'


### PR DESCRIPTION
  ## Summary                                                                                                                                                                      
  
- Add Sylius 2.0 / Symfony 7 compatibility (`artprima/prometheus-metrics-bundle ~1.21.0`)
 - Use `routing.yaml` instead of `routing.xml` (renamed in artprima >= 1.21.0)
 - Add `dist/config/routes/metrics.yaml` to override the broken Flex recipe (see:
   symfony/recipes-contrib#1948 and artprima/prometheus-metrics-bundle#132)
 - Restrict `sylius/sylius` constraint to `^1.14 || ^2.0`
 - Upgrade GitHub Actions to v4
 - Update CI matrix: drop Sylius 1.12/1.13 (EOL + security advisories), drop PHP 8.1, use Node 20 for Sylius 1.14 and Node 22 for Sylius 2.0