### PR TITLE
feat: add Sylius 2.1 support, restrict to Sylius 2.x only

### DIFF
--- a/.github/workflows/sylius.yaml
+++ b/.github/workflows/sylius.yaml
@@ -16,12 +16,12 @@ jobs:
           - 8.2
           - 8.3
         sylius:
-          - 1.14.0
           - 2.0.0
+          - 2.1.0
         include:
-          - sylius: 1.14.0
-            node-version: '20'
           - sylius: 2.0.0
+            node-version: '22'
+          - sylius: 2.1.0
             node-version: '22'
     env:
       SYMFONY_ARGS: --no-tls

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "description": "Sylius Prometheus Metrics Plugin",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
-        "sylius/sylius": "^1.14 || ^2.0",
+        "php": "^8.2",
+        "sylius/sylius": "^2.0",
         "artprima/prometheus-metrics-bundle": "~1.21.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Summary

  - Restrict sylius/sylius constraint to ^2.0 only (drop Sylius 1.14 support, moved to 1.x branch)
  - Restrict php constraint to ^8.2
  - Drop Sylius 1.14 from CI matrix
  - Add Sylius 2.1.0 to CI matrix